### PR TITLE
Add support for sample era

### DIFF
--- a/test/datasets/data_Run2015B.json
+++ b/test/datasets/data_Run2015B.json
@@ -3,30 +3,35 @@
     "name": "SingleElectron_Run2015B-PromptReco-v1_2015-08-27",
     "units_per_job": 200,
     "run_range": [246908,254879],
+    "era": "50ns",
     "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
   },
   "/SingleMuon/Run2015B-PromptReco-v1/MINIAOD": {
     "name": "SingleMuon_Run2015B-PromptReco-v1_2015-08-27",
     "units_per_job": 200,
     "run_range": [246908,254879],
+    "era": "50ns",
     "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
   },
   "/MuonEG/Run2015B-PromptReco-v1/MINIAOD": {
     "name": "MuonEG_Run2015B-PromptReco-v1_2015-08-27",
     "units_per_job": 200,
     "run_range": [246908,254879],
+    "era": "50ns",
     "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
   },
   "/DoubleMuon/Run2015B-PromptReco-v1/MINIAOD": {
     "name": "DoubleMuon_Run2015B-PromptReco-v1_2015-08-27",
     "units_per_job": 200,
     "run_range": [246908,254879],
+    "era": "50ns",
     "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
   },
   "/DoubleEG/Run2015B-PromptReco-v1/MINIAOD": {
     "name": "DoubleEG_Run2015B-PromptReco-v1_2015-08-27",
     "units_per_job": 200,
     "run_range": [246908,254879],
+    "era": "50ns",
     "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
   }
 }

--- a/test/datasets/data_Run2015C.json
+++ b/test/datasets/data_Run2015C.json
@@ -3,30 +3,35 @@
     "name": "SingleElectron_Run2015C-PromptReco-v1_2015-08-27",
     "units_per_job": 200,
     "run_range": [246908,254879],
+    "era": "25ns",
     "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
   },
   "/SingleMuon/Run2015C-PromptReco-v1/MINIAOD": {
     "name": "SingleMuon_Run2015C-PromptReco-v1_2015-08-27",
     "units_per_job": 200,
     "run_range": [246908,254879],
+    "era": "25ns",
     "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
   },
   "/MuonEG/Run2015C-PromptReco-v1/MINIAOD": {
     "name": "MuonEG_Run2015C-PromptReco-v1_2015-08-27",
     "units_per_job": 200,
     "run_range": [246908,254879],
+    "era": "25ns",
     "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
   },
   "/DoubleMuon/Run2015C-PromptReco-v1/MINIAOD": {
     "name": "DoubleMuon_Run2015C-PromptReco-v1_2015-08-27",
     "units_per_job": 200,
     "run_range": [246908,254879],
+    "era": "25ns",
     "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
   },
   "/DoubleEG/Run2015C-PromptReco-v1/MINIAOD": {
     "name": "DoubleEG_Run2015C-PromptReco-v1_2015-08-27",
     "units_per_job": 200,
     "run_range": [246908,254879],
+    "era": "25ns",
     "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
   }
 }

--- a/test/datasets/mc_DY.json
+++ b/test/datasets/mc_DY.json
@@ -1,10 +1,12 @@
 {
   "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v3/MINIAODSIM": {
     "name": "DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   }
 }

--- a/test/datasets/mc_SingleT.json
+++ b/test/datasets/mc_SingleT.json
@@ -1,15 +1,18 @@
 {
   "/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "ST_tW_top_5f_inclusiveDecays_13TeV-powheg_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   }
   ,
   "/ST_t-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "ST_t-channel_4f_leptonDecays_13TeV-amcatnlo_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   }
 }

--- a/test/datasets/mc_TT.json
+++ b/test/datasets/mc_TT.json
@@ -1,6 +1,7 @@
 {
   "/TTJets_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "TTJets_TuneCUETP8M1_amcatnloFXFX_25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   }
 }

--- a/test/datasets/mc_ggX0HH.json
+++ b/test/datasets/mc_ggX0HH.json
@@ -1,54 +1,67 @@
 {
   "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-260_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-260_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-270_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-270_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-300_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-300_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-350_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-350_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-400_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-400_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-450_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-450_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-500_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-500_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-550_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-550_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-600_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-600_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-650_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-650_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-700_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-700_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-800_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-800_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToRadionToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToRadionToHHTo2B2VTo2L2Nu_M-900_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   }
 }

--- a/test/datasets/mc_ggX2HH.json
+++ b/test/datasets/mc_ggX2HH.json
@@ -1,58 +1,72 @@
 {
   "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-260_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-260_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-270_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-270_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-300_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-300_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-350_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-350_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-400_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM": {
     "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-400_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-450_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-450_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-500_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-500_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-550_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-550_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-600_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-600_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-650_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-650_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-700_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-700_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-800_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-800_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-900_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-900_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   },
   "/GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-1000_narrow_13TeV-madgraph/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM": {
     "name": "GluGluToBulkGravitonToHHTo2B2VTo2L2Nu_M-1000_narrow_Asympt25ns",
-    "units_per_job": 15
+    "units_per_job": 15,
+    "era": "25ns"
   }
 }


### PR DESCRIPTION
Automatically adds the command-line option 'era' for all datasets. This option is red by the framework configuration file to switch various things.

As well, support is added for global tags over command-line.

Depends on cp3-llbb/Framework#45
