### PR TITLE
Change process name to RECO when running on PromptReco

### DIFF
--- a/scripts/runOnGrid.py
+++ b/scripts/runOnGrid.py
@@ -102,6 +102,10 @@ def submit(dataset, opt):
     if 'globalTag' in opt:
         pyCfgParams += ['globalTag=%s' % opt['globalTag']]
 
+    # Fix process name for PromptReco, which is RECO instead of PAT
+    if options.data and 'PromptReco' in dataset:
+        pyCfgParams += ['process=RECO']
+
     c.JobType.pyCfgParams = pyCfgParams
 
     print("Submitting new task %r" % opt['name'])


### PR DESCRIPTION
As title says. It's needed because of cp3-llbb/Framework#51

The solution is to force using the RECO process name when running on prompt reco.
