### PR TITLE
Updated data JSON; added some MC

### DIFF
--- a/test/datasets/data_Run2015B.json
+++ b/test/datasets/data_Run2015B.json
@@ -1,37 +1,37 @@
 {
   "/SingleElectron/Run2015B-PromptReco-v1/MINIAOD": {
-    "name": "SingleElectron_Run2015B-PromptReco-v1_2015-08-27",
+    "name": "SingleElectron_Run2015B-PromptReco-v1_2015-09-17",
     "units_per_job": 200,
-    "run_range": [246908,254879],
+    "run_range": [246908,255031],
     "era": "50ns",
-    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
+    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-255031_13TeV_PromptReco_Collisions15_50ns_JSON_v2.txt"
   },
   "/SingleMuon/Run2015B-PromptReco-v1/MINIAOD": {
-    "name": "SingleMuon_Run2015B-PromptReco-v1_2015-08-27",
+    "name": "SingleMuon_Run2015B-PromptReco-v1_2015-09-17",
     "units_per_job": 200,
-    "run_range": [246908,254879],
+    "run_range": [246908,255031],
     "era": "50ns",
-    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
+    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-255031_13TeV_PromptReco_Collisions15_50ns_JSON_v2.txt"
   },
   "/MuonEG/Run2015B-PromptReco-v1/MINIAOD": {
-    "name": "MuonEG_Run2015B-PromptReco-v1_2015-08-27",
+    "name": "MuonEG_Run2015B-PromptReco-v1_2015-09-17",
     "units_per_job": 200,
-    "run_range": [246908,254879],
+    "run_range": [246908,255031],
     "era": "50ns",
-    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
+    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-255031_13TeV_PromptReco_Collisions15_50ns_JSON_v2.txt"
   },
   "/DoubleMuon/Run2015B-PromptReco-v1/MINIAOD": {
-    "name": "DoubleMuon_Run2015B-PromptReco-v1_2015-08-27",
+    "name": "DoubleMuon_Run2015B-PromptReco-v1_2015-09-17",
     "units_per_job": 200,
-    "run_range": [246908,254879],
+    "run_range": [246908,255031],
     "era": "50ns",
-    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
+    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-255031_13TeV_PromptReco_Collisions15_50ns_JSON_v2.txt"
   },
   "/DoubleEG/Run2015B-PromptReco-v1/MINIAOD": {
-    "name": "DoubleEG_Run2015B-PromptReco-v1_2015-08-27",
+    "name": "DoubleEG_Run2015B-PromptReco-v1_2015-09-17",
     "units_per_job": 200,
-    "run_range": [246908,254879],
+    "run_range": [246908,255031],
     "era": "50ns",
-    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
+    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-255031_13TeV_PromptReco_Collisions15_50ns_JSON_v2.txt"
   }
 }

--- a/test/datasets/data_Run2015C.json
+++ b/test/datasets/data_Run2015C.json
@@ -1,37 +1,37 @@
 {
   "/SingleElectron/Run2015C-PromptReco-v1/MINIAOD": {
-    "name": "SingleElectron_Run2015C-PromptReco-v1_2015-08-27",
+    "name": "SingleElectron_Run2015C-PromptReco-v1_2015-09-04",
     "units_per_job": 200,
-    "run_range": [246908,254879],
+    "run_range": [246908,255031],
     "era": "25ns",
-    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
+    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-255031_13TeV_PromptReco_Collisions15_25ns_JSON_v2.txt"
   },
   "/SingleMuon/Run2015C-PromptReco-v1/MINIAOD": {
-    "name": "SingleMuon_Run2015C-PromptReco-v1_2015-08-27",
+    "name": "SingleMuon_Run2015C-PromptReco-v1_2015-09-04",
     "units_per_job": 200,
-    "run_range": [246908,254879],
+    "run_range": [246908,255031],
     "era": "25ns",
-    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
+    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-255031_13TeV_PromptReco_Collisions15_25ns_JSON_v2.txt"
   },
   "/MuonEG/Run2015C-PromptReco-v1/MINIAOD": {
-    "name": "MuonEG_Run2015C-PromptReco-v1_2015-08-27",
+    "name": "MuonEG_Run2015C-PromptReco-v1_2015-09-04",
     "units_per_job": 200,
-    "run_range": [246908,254879],
+    "run_range": [246908,255031],
     "era": "25ns",
-    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
+    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-255031_13TeV_PromptReco_Collisions15_25ns_JSON_v2.txt"
   },
   "/DoubleMuon/Run2015C-PromptReco-v1/MINIAOD": {
-    "name": "DoubleMuon_Run2015C-PromptReco-v1_2015-08-27",
+    "name": "DoubleMuon_Run2015C-PromptReco-v1_2015-09-04",
     "units_per_job": 200,
-    "run_range": [246908,254879],
+    "run_range": [246908,255031],
     "era": "25ns",
-    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
+    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-255031_13TeV_PromptReco_Collisions15_25ns_JSON_v2.txt"
   },
   "/DoubleEG/Run2015C-PromptReco-v1/MINIAOD": {
-    "name": "DoubleEG_Run2015C-PromptReco-v1_2015-08-27",
+    "name": "DoubleEG_Run2015C-PromptReco-v1_2015-09-04",
     "units_per_job": 200,
-    "run_range": [246908,254879],
+    "run_range": [246908,255031],
     "era": "25ns",
-    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-254879_13TeV_PromptReco_Collisions15_JSON.txt"
+    "certified_lumi_file":"https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-255031_13TeV_PromptReco_Collisions15_25ns_JSON_v2.txt"
   }
 }

--- a/test/datasets/mc_DY.json
+++ b/test/datasets/mc_DY.json
@@ -1,12 +1,12 @@
 {
   "/DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "DYJetsToLL_M-10to50_TuneCUETP8M1_13TeV-amcatnloFXFX_Asympt25ns",
-    "units_per_job": 15,
+    "units_per_job": 5,
     "era": "25ns"
   },
   "/DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v3/MINIAODSIM": {
     "name": "DYJetsToLL_M-50_TuneCUETP8M1_13TeV-amcatnloFXFX_Asympt25ns",
-    "units_per_job": 15,
+    "units_per_job": 5,
     "era": "25ns"
   }
 }

--- a/test/datasets/mc_SingleT.json
+++ b/test/datasets/mc_SingleT.json
@@ -1,18 +1,27 @@
 {
   "/ST_tW_top_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
-    "name": "ST_tW_top_5f_inclusiveDecays_13TeV-powheg_Asympt25ns",
-    "units_per_job": 15,
+    "name": "ST_tW_top_5f_inclusiveDecays_13TeV-powheg_25ns",
+    "units_per_job": 5,
     "era": "25ns"
   },
   "/ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
-    "name": "ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg_Asympt25ns",
-    "units_per_job": 15,
+    "name": "ST_tW_antitop_5f_inclusiveDecays_13TeV-powheg_25ns",
+    "units_per_job": 5,
     "era": "25ns"
-  }
-  ,
+  },
   "/ST_t-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
-    "name": "ST_t-channel_4f_leptonDecays_13TeV-amcatnlo_Asympt25ns",
-    "units_per_job": 15,
+    "name": "ST_t-channel_4f_leptonDecays_13TeV-amcatnlo_25ns",
+    "units_per_job": 5,
     "era": "25ns"
-  }
+  },
+  "/ST_t-channel_antitop_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
+    "name": "ST_t-channel_antitop_4f_leptonDecays_13TeV-powheg-pythia8_25ns",
+    "units_per_job": 5,
+    "era": "25ns"
+  },
+  "/ST_t-channel_top_4f_leptonDecays_13TeV-powheg-pythia8_TuneCUETP8M1/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
+    "name": "ST_t-channel_top_4f_leptonDecays_13TeV-powheg-pythia8_25ns",
+    "units_per_job": 5,
+    "era": "25ns"
+  },
 }

--- a/test/datasets/mc_TT.json
+++ b/test/datasets/mc_TT.json
@@ -1,17 +1,22 @@
 {
+  "/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM": {
+    "name": "TT_TuneCUETP8M1_13TeV-powheg-pythia8_25ns",
+    "units_per_job": 15,
+    "era": "25ns"
+  },
   "/TTTo2L2Nu_13TeV-powheg/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
     "name": "TTTo2L2Nu_13TeV-powheg_25ns",
-    "units_per_job": 15,
+    "units_per_job": 5,
     "era": "25ns"
   },
-  "/TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
-    "name": "TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8_25ns",
-    "units_per_job": 15,
+  "/TT_Mtt-1000toInf_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9_ext1-v2/MINIAODSIM": {
+    "name": "TT_Mtt-1000toInf_TuneCUETP8M1_13TeV-powheg-pythia8_25ns",
+    "units_per_job": 5,
     "era": "25ns"
   },
-  "/TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
-    "name": "TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8_25ns",
-    "units_per_job": 15,
+  "/TT_Mtt-700to1000_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9_ext1-v1/MINIAODSIM": {
+    "name": "TT_Mtt-700to1000_TuneCUETP8M1_13TeV-powheg-pythia8_25ns",
+    "units_per_job": 5,
     "era": "25ns"
-  }
+  },
 }

--- a/test/datasets/mc_TTV.json
+++ b/test/datasets/mc_TTV.json
@@ -1,0 +1,22 @@
+{
+  "/TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
+    "name": "TTZToLLNuNu_M-10_TuneCUETP8M1_13TeV-amcatnlo-pythia8_25ns",
+    "units_per_job": 5,
+    "era": "25ns"
+  },
+  "/TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
+    "name": "TTZToQQ_TuneCUETP8M1_13TeV-amcatnlo-pythia8_25ns",
+    "units_per_job": 5,
+    "era": "25ns"
+  },
+  "/TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
+    "name": "TTWJetsToLNu_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8_25ns",
+    "units_per_job": 5,
+    "era": "25ns"
+  },
+  "/TTWJetsToQQ_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v1/MINIAODSIM": {
+    "name": "TTWJetsToQQ_TuneCUETP8M1_13TeV-amcatnloFXFX-madspin-pythia8_25ns",
+    "units_per_job": 5,
+    "era": "25ns"
+  }
+}


### PR DESCRIPTION
- Updated 2015B & 2015C with latest Golden JSONs (re-reco & 2015D with almost 0.5 fb-1 will not be long now I guess?)
- Added some ttbar MC (TTV, high-mass ttbar, and "the" official ttbar MC sample)
- Scaled down number of units/job to more practical values for some samples

I didn't add more since re-miniAOD in 7412 will come soon anyway.
