### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ already included (see inside ``test/datasets``). The structure of the JSON file 
 You can now run on the grid. Go to the ``test`` folder, and run
 
 ```bash
-runOnGrid.py -f datasets/mc_TT.json -c <Your_Configuration_File> --mc
+runOnGrid.py -c <Your_Configuration_File> --mc datasets/mc_TT.json datasets/mc_DY.json <datasets/...>
 ```
 
 ``<Your_Configuration_File>`` must be substituted by the name of the configuration file, *including the ``.py`` extension*.

--- a/scripts/runOnGrid.py
+++ b/scripts/runOnGrid.py
@@ -36,6 +36,9 @@ def get_options():
     parser.add_argument('-j', '--cores', type=int, action='store', dest='processes', metavar='N', default='4',
                         help='Number of core to use during the crab tasks creation')
 
+    parser.add_argument('-l', '--lumi-mask', type=str, required=False, dest='lumi_mask', metavar='URL',
+                        help='URL to the luminosity mask to use when running on data')
+
     options = parser.parse_args()
 
     if options.datasets is None:
@@ -123,8 +126,10 @@ def submit(dataset, opt):
 
     if options.data:
         c.Data.runRange = '%d-%d' % (opt['run_range'][0], opt['run_range'][1])
-        c.Data.lumiMask = opt['certified_lumi_file'] if 'certified_lumi_file' in opt else\
-            'https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions15/13TeV/Cert_246908-247381_13TeV_PromptReco_Collisions15_ZeroTesla_JSON.txt'
+        if not 'certified_lumi_file' in opt and not options.lumi_mask:
+            raise Exception('You are running on data but no luminosity mask is specified for task %r. Please add the \'--lumi-mask\' argument or use the \'certified_lumi_file\' key inside the JSON file' % (opt['name']))
+
+        c.Data.lumiMask = options.lumi_mask if options.lumi_mask else opt['certified_lumi_file']
 
     # Create output file in case something goes wrong with submit
     crab_config_file = 'crab_' + opt['name'] + '.py'

--- a/scripts/runOnGrid.py
+++ b/scripts/runOnGrid.py
@@ -20,8 +20,6 @@ def get_options():
     Parse and return the arguments provided by the user.
     """
     parser = argparse.ArgumentParser(description='Launch crab over multiple datasets.')
-    parser.add_argument('-f', '--datasets', type=str, required=True, action='append', dest='datasets', metavar='FILE',
-                        help='JSON files listings datasets to run over.')
 
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument('--mc', action='store_true', dest='mc', help='Run over MC datasets',)
@@ -38,6 +36,9 @@ def get_options():
 
     parser.add_argument('-l', '--lumi-mask', type=str, required=False, dest='lumi_mask', metavar='URL',
                         help='URL to the luminosity mask to use when running on data')
+
+    parser.add_argument('datasets', type=str, nargs='+', metavar='FILE',
+                        help='JSON files listings datasets to run over.')
 
     options = parser.parse_args()
 


### PR DESCRIPTION
Some improvements for runOnGrid:
- Add a new command line argument `--lumi-mask <url>` to override all the lumi masks specified in the JSON files. Useful to use the latest JSON without editing all the files
- Change a bit the parameters of `runOnGrid` to allow multiple input files using bash wildcards:

``` bash
runOnGrid.py --mc -c MyConfig.py datasets/mc_*.json
```

It's no longer necessary to add the `-f` flag for each input file
