### PR TITLE
Parameter Data.publishDataName has been renamed

### DIFF
--- a/scripts/runOnGrid.py
+++ b/scripts/runOnGrid.py
@@ -102,7 +102,7 @@ def submit(dataset, opt):
         c.JobType.inputFiles += module.process.gridin.input_files
 
     c.General.requestName = opt['name']
-    c.Data.publishDataName = opt['name']
+    c.Data.outputDatasetTag = opt['name']
 
     c.Data.inputDataset = dataset
     c.Data.unitsPerJob = opt['units_per_job']


### PR DESCRIPTION
Parameter Data.publishDataName has been renamed to Data.outputDatasetTag starting from CRAB v3.3.1511

(Nota Bene: don't forget to scram build to have the latest runOnGrid.py from this PR...)
