### PR TITLE
Tweak TT json

### DIFF
--- a/test/datasets/mc_TT.json
+++ b/test/datasets/mc_TT.json
@@ -1,5 +1,5 @@
 {
-  "/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM": {
+  "/TT_TuneCUETP8M1_13TeV-powheg-pythia8/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2_ext3-v1/MINIAODSIM": {
     "name": "TT_TuneCUETP8M1_13TeV-powheg-pythia8_MiniAODv2",
     "units_per_job": 3,
     "era": "25ns"

--- a/test/datasets/mc_TT_fully_leptonic.json
+++ b/test/datasets/mc_TT_fully_leptonic.json
@@ -1,0 +1,7 @@
+{
+  "/TTTo2L2Nu_13TeV-powheg/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM": {
+    "name": "TTTo2L2Nu_13TeV-powheg_MiniAODv2",
+    "units_per_job": 3,
+    "era": "25ns"
+  }
+}

--- a/test/datasets/mc_TT_inclusive.json
+++ b/test/datasets/mc_TT_inclusive.json
@@ -3,10 +3,5 @@
     "name": "TT_TuneCUETP8M1_13TeV-powheg-pythia8_MiniAODv2",
     "units_per_job": 3,
     "era": "25ns"
-  },
-  "/TTTo2L2Nu_13TeV-powheg/RunIISpring15MiniAODv2-74X_mcRun2_asymptotic_v2-v1/MINIAODSIM": {
-    "name": "TTTo2L2Nu_13TeV-powheg_MiniAODv2",
-    "units_per_job": 3,
-    "era": "25ns"
   }
 }


### PR DESCRIPTION
Two things:
- Split TT json into two JSON, one for inclusive and one for fully leptonic
- Put the big guns out, and switch to the high stat TT sample (~97M events vs ~20M)
