### PR TITLE
Ask ROOT to ignore command-line options in runPostCrab.py

### DIFF
--- a/scripts/runPostCrab.py
+++ b/scripts/runPostCrab.py
@@ -29,6 +29,7 @@ from CRABAPI.RawCommand import crabCommand
 
 # import a bit of ROOT
 import ROOT
+ROOT.PyConfig.IgnoreCommandLineOptions = True
 ROOT.gROOT.Reset()
 
 def get_file_data(pfn):


### PR DESCRIPTION
super-minor issue: this makes runPostCrab.py -h/--help work again
