### PR TITLE
Improve post-crab step

### DIFF
--- a/scripts/runOnGrid.py
+++ b/scripts/runOnGrid.py
@@ -169,6 +169,10 @@ def submit(job):
 
     c.JobType.pyCfgParams = pyCfgParams
 
+    # Some jobs may request more memory
+    if 'memory' in job['metadata']:
+        c.JobType.maxMemoryMB = job['metadata']['memory']
+
     print("Submitting new task %r" % c.General.requestName)
     print("\tDataset: %s" % job['dataset'])
 


### PR DESCRIPTION
Two unrelated commit:

  - First one change a bit `runPostCrab.py` to except crab folder instead of python configuration file as input. This allows multiple production in parallel, or to remove `.py` files once the tasks are launched
  - Last commit is for `runOnGrid.py`, allowing a dataset to request more RAM. Useful to overcome https://hypernews.cern.ch/HyperNews/CMS/get/generators/3122.html for example, since all site accepts 2500 MB for a job, and crab asks for 2000 MB by default.