### PR TITLE
`load_file` -> `load_request`

### DIFF
--- a/scripts/checkMyProd.py
+++ b/scripts/checkMyProd.py
@@ -71,8 +71,8 @@ def main():
     outjson = options.outjson
     if options.new:
         # NB: assumes all the on-going tasks are for the same analyzer
-        module = runPostCrab.load_file(alltasks[0] + '.py')
-        psetName = module.config.JobType.psetName
+        module = runPostCrab.load_request('tasks/' + alltasks[0])
+        psetName = module['OriginalConfig'].JobType.psetName
         print "##### Figure out the code(s) version"
         # first the version of the framework
         FWHash, FWRepo, FWUrl = runPostCrab.getGitTagRepoUrl( os.path.join(CMSSW_BASE, 'src/cp3_llbb/Framework') )


### PR DESCRIPTION
`checkMyProd.py` was inadvertently broken by https://github.com/cp3-llbb/GridIn/pull/91