### PR TITLE
Fix for crab submission after Framework MVA id

### DIFF
--- a/python/default_crab_config.py
+++ b/python/default_crab_config.py
@@ -17,6 +17,7 @@ def create_config(is_mc):
     config.JobType.disableAutomaticOutputCollection = True
     config.JobType.outputFiles = []
     config.JobType.allowUndistributedCMSSW = True
+    config.JobType.sendExternalFolder = True # To send electron MVA ids with jobs
 
     config.Data.inputDBS = 'global'
 

--- a/scripts/checkMyProd.py
+++ b/scripts/checkMyProd.py
@@ -138,15 +138,19 @@ def main():
     #    * SUBMITFAILED -> suggest to rm -r the task and submit again
     #####
     print "##### ##### Suggested actions ##### #####"
-    if len(tasks['COMPLETED']) + len(tasks['SUBMITFAILED']) > 0:
+    if len(tasks['COMPLETED']) + len(tasks['SUBMITFAILED']) + len(tasks['FAILED']) > 0:
         if len(tasks['COMPLETED']) > 0:
             print "##### COMPLETED tasks #####"
             for task in tasks['COMPLETED']:
-                print "runPostCrab.py", task + ".py"
+                print "runPostCrab.py tasks/" + task
         if len(tasks['SUBMITFAILED']) > 0:
             print "##### SUBMITFAILED tasks #####"
             for task in tasks['SUBMITFAILED']:
                 print "rm -r tasks/" + task + "; crab submit " + task + ".py"
+        if len(tasks['FAILED']) > 0:
+            print "##### FAILED tasks #####"
+            for task in tasks['FAILED']:
+                print "crab resubmit tasks/" + task
     else:
         print "None"
 

--- a/scripts/runPostCrab.py
+++ b/scripts/runPostCrab.py
@@ -32,6 +32,29 @@ import ROOT
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 ROOT.gROOT.Reset()
 
+# Print iterations progress
+def print_progress(iteration, total, prefix='', suffix='', decimals=1, bar_length=40):
+    """
+    Call in a loop to create terminal progress bar
+    @params:
+        iteration   - Required  : current iteration (Int)
+        total       - Required  : total iterations (Int)
+        prefix      - Optional  : prefix string (Str)
+        suffix      - Optional  : suffix string (Str)
+        decimals    - Optional  : positive number of decimals in percent complete (Int)
+        bar_length  - Optional  : character length of bar (Int)
+    """
+    str_format = "{0:." + str(decimals) + "f}"
+    percents = str_format.format(100 * (iteration / float(total)))
+    filled_length = int(round(bar_length * iteration / float(total)))
+    bar = '█' * filled_length + '-' * (bar_length - filled_length)
+
+    sys.stdout.write('\r%s |%s| %s%s %s' % (prefix, bar, percents, '%', suffix)),
+
+    if iteration == total:
+        sys.stdout.write('\n')
+    sys.stdout.flush()
+
 def get_file_data(pfn):
     """
     Return the sum of event weights and the entries of the framework output
@@ -272,7 +295,7 @@ def main():
 
     print("")
 
-    print "##### Get information from the output files"
+    print "##### Get information from the output files (%d files)" % (len(output_files['lfn']))
     files = []
     for (i, lfn) in enumerate(output_files['lfn']):
         pfn = output_files['pfn'][i]
@@ -289,8 +312,10 @@ def main():
     dataset_extras_sumw = {}
     dataset_nselected = 0
     file_missing = False
-    for f in files:
+    print_progress(0, len(files), prefix='Progress:')
+    for i, f in enumerate(files):
         (sumw, extras_sumw, entries) = get_file_data(storagePrefix + f['lfn'])
+        print_progress(i + 1, len(files), prefix='Progress:')
         if not sumw:
             print("Warning: failed to retrieve sum of event weight for %r" % f['lfn'])
             file_missing = True


### PR DESCRIPTION
Electrons MVA id training is not included yet into CMSSW, so ones has to clone by hand the git repo containing those files into the `external` CMSSW folder. By default, this folder is not sent with the job by crab. This PR turns on the magic flag doing that.

There's also some cosmetics change for runPostCrab and checkMyProd