### PR TITLE
Small improvements

### DIFF
--- a/scripts/checkMyProd.py
+++ b/scripts/checkMyProd.py
@@ -147,6 +147,15 @@ def main():
             continue
         line = key + ": " + str(len(tasks[key]))
         print line
+
+    def format_blacklist():
+        if os.path.isfile("blacklist.txt"):
+            with open("blacklist.txt") as f:
+                sites = f.readlines()
+                if len(sites) > 0:
+                    return " --siteblacklist={}".format(",".join(sites))
+
+        return ""
     
     #####
     # Suggest some actions depending on the crab status
@@ -161,15 +170,15 @@ def main():
     if len(tasks['SUBMITFAILED']) > 0:
         print "##### SUBMITFAILED tasks #####"
         for task in tasks['SUBMITFAILED']:
-            print "rm -r tasks/" + task + "; crab submit " + task + ".py"
+            print "rm -r tasks/" + task + "; crab submit " + task + ".py" + format_blacklist
     if len(tasks['FAILED']) > 0:
         print "##### FAILED tasks #####"
         for task in tasks['FAILED']:
-            print "crab resubmit tasks/" + task
+            print "crab resubmit tasks/" + task + format_blacklist()
     if len(tasks['TORESUBMIT']) > 0:
         print "##### TORESUBMIT tasks #####"
         for task in tasks['TORESUBMIT']:
-            print "crab resubmit tasks/" + task + " --siteblacklist=T2_UK_SGrid_RALPP,T1_US_FNAL"
+            print "crab resubmit tasks/" + task + format_blacklist()
 
 if __name__ == '__main__':
     main()

--- a/scripts/runOnGrid.py
+++ b/scripts/runOnGrid.py
@@ -213,7 +213,18 @@ for name, analysis in analyses.items():
 
     def globMatch(value, pattern):
         import fnmatch
-        return fnmatch.fnmatch(value, pattern)
+
+        # If pattern starts with a '!', negate the result
+        negate = False
+        if pattern[0] == '!':
+            pattern = pattern[1:]
+            negate = True
+
+        result = fnmatch.fnmatch(value, pattern)
+        if negate:
+            return not result
+        else:
+            return result
 
     def globIn(value, patterns):
         """


### PR DESCRIPTION
Two things not related:
 - Support for negate filters in `runOnGrid`. Just prefix the glob pattern by `!` to inverse the matching
 - Support for custom blacklist in `checkMyProd`. Create a text file named `blacklist.txt` and add one site per line. They'll automatically be added to the list of suggested actions.