### PR TITLE
A few small fixes/improvements for checkMyProd

### DIFF
--- a/scripts/checkMyProd.py
+++ b/scripts/checkMyProd.py
@@ -38,6 +38,7 @@ def get_options():
     parser.add_argument('--new', action='store_true', help='Start monitoring a new production', dest='new')
     parser.add_argument('-j', '--json', type=str, action='store', dest='outjson', default='prod_default.json',
                         help='json file storing the status of your on-going production') 
+    parser.add_argument("--recheckcompleted", action="store_true", help="Also check the status of jobs marked as 'completed' again", dest="recheckcompleted")
     options = parser.parse_args()
     return options
 
@@ -114,7 +115,7 @@ def main():
             if unicode(task) in data[u'GRIDIN-INDB']:
                 tasks['GRIDIN-INDB'].append(task)
                 continue
-            elif unicode(task) in data[u'COMPLETED']:
+            elif ( not options.recheckcompleted ) and unicode(task) in data[u'COMPLETED']:
                 tasks['COMPLETED'].append(task)
                 continue
         taskdir = os.path.join('tasks/', task)


### PR DESCRIPTION
- do not re-check status for "COMPLETED" tasks (same as "GRIDIN-INDB"). This saves time for me (I add my samples to the database when everything is done only) - let me know if this breaks your workflow, we can make this optional with a command-line switch
- workaround for a CRAB API issue (where the returned status is always SUBMITTED, even if there are failed subjobs or all are completed), see https://github.com/dmwm/CRABClient/issues/4702 and a discussion on the computing-tools hypernews
- a typo

Note: will rebase after https://github.com/cp3-llbb/GridIn/pull/104 is merged