### PR TITLE
Define CMSSW_BASE

### DIFF
--- a/scripts/checkMyProd.py
+++ b/scripts/checkMyProd.py
@@ -10,6 +10,9 @@ import re
 
 import CRABClient
 
+# import CMSSW stuff
+CMSSW_BASE = os.environ['CMSSW_BASE']
+
 from cp3_llbb.SAMADhi.SAMADhi import Dataset, Sample, File, DbStore
 
 from cp3_llbb.GridIn import utils


### PR DESCRIPTION
This was needed for getting the git tags, but removed by https://github.com/cp3-llbb/GridIn/pull/108