### PR TITLE
Update samples whitelist for TTW

### DIFF
--- a/data/SAMADhi_doNOTdelete_whitelist.json
+++ b/data/SAMADhi_doNOTdelete_whitelist.json
@@ -13,6 +13,9 @@
         "v1.2.0+7415-75-g2a48fa7_TTAnalysis_fd2fe94"
     ],
     "TTWAnalysis": [
+        "v5.0.1+80X-10-g9c892ce_TTWAnalysis_88d2abe",
+        "v6.0.0+80X-14-gec8dd91_TTWAnalysis_ebb2692",
+        "v6.0.0+80X-18-g6a2d7a8_TTWAnalysis_ce9ffb3",
     ],
     "ZAAnalysis": [
     ]


### PR DESCRIPTION
`v6.0.0+80X-14-gec8dd91_TTWAnalysis_ebb2692` I only used for one extension (it's equivalent to `v5.0.1+80X-10-g9c892ce_TTWAnalysis_88d2abe`), so these are two productions, in the end (and probably I could do without the first, if there is a disk space problem).