### PR TITLE
Improve task status detection for automatic splitting

### DIFF
--- a/scripts/checkMyProd.py
+++ b/scripts/checkMyProd.py
@@ -136,7 +136,7 @@ def main():
                 if status_code == "SUBMITTED": ## can already try to resubmit if any of the followup stages have failed jobs
                     jobsPerStage = jobstatusPerStage(status["jobList"])
                     lSt = "0" if len(jobsPerStage) == 1 else max(jobsPerStage.iterkeys(), key=lambda st : int(st))
-                    if any(jst == "FAILED" for sji,jst in jobsPerStage[lSt].iteritems()):
+                    if any(jst == "failed" for sji,jst in jobsPerStage[lSt].iteritems()):
                         status_code = "TORESUBMIT"
             tasks[status_code].append(task)
         except CRABClient.ClientExceptions.CachefileNotFoundException:

--- a/scripts/runOnGrid.py
+++ b/scripts/runOnGrid.py
@@ -122,7 +122,10 @@ def submit(job):
     c = copy.deepcopy(job['crab_config'])
 
     c.JobType.psetName = job['pset']
-    c.JobType.outputFiles.append(module.process.framework.output.value())
+    if hasattr(module.process, "framework") and hasattr(module.process.framework, "output"):
+        c.JobType.outputFiles.append(module.process.framework.output.value())
+    if hasattr(module.process, "TFileService") and hasattr(module.process.TFileService, "fileName"):
+        c.JobType.outputFiles.append(module.process.TFileService.fileName.value())
 
     if hasattr(module.process, 'gridin') and hasattr(module.process.gridin, 'input_files') and len(module.process.gridin.input_files) > 0:
         if not hasattr(c.JobType, 'inputFiles'):


### PR DESCRIPTION
I removed the old workaround (that CRAB bug is fixed), and removed the code that automatically marks the task failed if any job is (otherwise some jobs keep coming back in the "to resubmit" list because an early-stage job failed, even if the recovery jobs succeeded). It's a bit of heuristics, so not perfect, but it seems to work fine on the production I'm running at the moment.